### PR TITLE
fix(typing): use ComponentType as returned type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,7 @@ export { Box } from './Box';
 export type PolymorphicComponentProps<E extends React.ElementType, P> = P &
   BoxProps<E>;
 
-export type PolymorphicComponent<P, D extends React.ElementType = 'div'> = <
-  E extends React.ElementType = D
->(
-  props: PolymorphicComponentProps<E, P>,
-) => JSX.Element;
+export type PolymorphicComponent<
+  P,
+  D extends React.ElementType = 'div'
+> = React.ComponentType<PolymorphicComponentProps<D, P>>;


### PR DESCRIPTION
I saw there was a generic used here, but did not quite understand why it was there. This PR returns an actual `ComponentType`, meaning that things like `defaultProps` etc. is also typed as normal.

Hopefully it makes sense 😄 