### PR TITLE
perf(typing): improve performance of PropsOf

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,9 @@
-// Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
-export type PropsOf<
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	E extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
-> = JSX.LibraryManagedAttributes<E, React.ComponentPropsWithRef<E>>;
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Source: https://github.com/chakra-ui/chakra-ui/blob/develop/packages/system/src/forward-ref.tsx
+type As = string | React.ComponentType<any>;
+
+export type PropsOf<T extends As> = T extends keyof JSX.IntrinsicElements
+	? JSX.IntrinsicElements[T]
+	: T extends React.JSXElementConstructor<any>
+	? JSX.LibraryManagedAttributes<T, React.ComponentPropsWithRef<T>>
+	: never;


### PR DESCRIPTION
First of all, thank you for the work you put into this library as it makes creating polymorphic components so easy!  The only pain point I've had with this library is that the performance of type checking takes a fairly significant hit compared to standard type checking.  After a lot of digging and looking at what other component libraries are doing to solve this problem, I found the approach that Chakra UI took in https://github.com/chakra-ui/chakra-ui/pull/1627 made a significant impact on performance by not using `JSX.IntrinsicElements` when typing the as prop and instead using `string`.  Through the use of conditional types, it can still maintain the same strong typing.

The following screenshot shows the delay in type checking with the existing approach and then the improved speed with the new approach in this PR.

![perf](https://user-images.githubusercontent.com/25914066/94849927-c3140880-03eb-11eb-8014-96b2c2c971f3.gif)

This is my test cases to ensure the type checking is working properly.

<img width="681" alt="Screen Shot 2020-10-01 at 1 32 18 PM" src="https://user-images.githubusercontent.com/25914066/94850003-e63eb800-03eb-11eb-8c3c-3b18476b407c.png">