### PR TITLE
Update peer dependency to allow React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,6 @@
 		"typescript": "^4.0.3"
 	},
 	"peerDependencies": {
-		"react": "^16.3.0 || ^17.0.0"
+		"react": ">=16.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,6 @@
 		"typescript": "^4.0.3"
 	},
 	"peerDependencies": {
-		"react": "^16.3.0"
+		"react": "^16.3.0 || ^17.0.0"
 	}
 }


### PR DESCRIPTION
React 17 has been released for a few weeks now, but I noticed that the peer dependency in this library doesn't allow react 17.  This fixes that issue.